### PR TITLE
Using traceback to expose proper Python errors in logs

### DIFF
--- a/loader-config.yml
+++ b/loader-config.yml
@@ -1,7 +1,7 @@
 extensions:
   - name: python
     file_extension: py
-    source_lib: ./target/debug/libpy_source.so
-    sink_lib: ./target/debug/libpy_sink.so
-    operator_lib: ./target/debug/libpy_op.so
+    source_lib: ./target/release/libpy_source.so
+    sink_lib: ./target/release/libpy_sink.so
+    operator_lib: ./target/release/libpy_op.so
     config_lib_key: python-script

--- a/loader-config.yml
+++ b/loader-config.yml
@@ -1,7 +1,7 @@
 extensions:
   - name: python
     file_extension: py
-    source_lib: ./target/release/libpy_source.so
-    sink_lib: ./target/release/libpy_sink.so
-    operator_lib: ./target/release/libpy_op.so
+    source_lib: ./target/debug/libpy_source.so
+    sink_lib: ./target/debug/libpy_sink.so
+    operator_lib: ./target/debug/libpy_op.so
     config_lib_key: python-script

--- a/py-op/Cargo.toml
+++ b/py-op/Cargo.toml
@@ -17,16 +17,16 @@ readme = "README.md"
 [dependencies]
 zenoh-flow = { git = "https://github.com/eclipse-zenoh/zenoh-flow.git", branch = "master"}
 zenoh-flow-python-types = {path = "../zenoh-flow-python-types/"}
-pyo3 = "0.15"
+pyo3 = "0.16"
 log = "0.4"
 libloading = "0.7"
 
 [build-dependencies]
-pyo3-build-config = {version = "0.15", features = ["resolve-config"]}
+pyo3-build-config = {version = "0.16", features = ["resolve-config"]}
 
 [features]
-abi-py36 = ["pyo3/abi3-py36"]
-default = ["abi-py36"]
+abi-py37 = ["pyo3/abi3-py37"]
+default = ["abi-py37"]
 
 [lib]
 name = "py_op"

--- a/py-op/src/lib.rs
+++ b/py-op/src/lib.rs
@@ -223,7 +223,8 @@ impl Node for PyOperator {
                 let py_config = config["configuration"].take();
 
                 // Convert configuration to Python
-                let py_config = configuration_into_py(py, py_config);
+                let py_config = configuration_into_py(py, py_config)
+                .map_err(|e| from_pyerr_to_zferr(e, &py))?;
 
                 // Load Python code
                 let code = read_file(script_file_path)?;

--- a/py-sink/Cargo.toml
+++ b/py-sink/Cargo.toml
@@ -10,16 +10,16 @@ edition = "2018"
 zenoh-flow = { git = "https://github.com/eclipse-zenoh/zenoh-flow.git", branch = "master"}
 async-trait = "0.1"
 zenoh-flow-python-types = {path = "../zenoh-flow-python-types/"}
-pyo3 = "0.15"
+pyo3 = "0.16"
 libloading = "0.7"
 log = "0.4"
 
 [build-dependencies]
-pyo3-build-config = {version = "0.15", features = ["resolve-config"]}
+pyo3-build-config = {version = "0.16", features = ["resolve-config"]}
 
 [features]
-abi-py36 = ["pyo3/abi3-py36"]
-default = ["abi-py36"]
+abi-py37 = ["pyo3/abi3-py37"]
+default = ["abi-py37"]
 
 [lib]
 name = "py_sink"

--- a/py-sink/src/lib.rs
+++ b/py-sink/src/lib.rs
@@ -7,6 +7,7 @@ use zenoh_flow::async_std::sync::Arc;
 use zenoh_flow::zenoh_flow_derive::ZFState;
 use zenoh_flow::Configuration;
 use zenoh_flow::{DataMessage, Node, Sink, State, ZFError, ZFResult};
+use zenoh_flow_python_types::from_pyerr_to_zferr;
 use zenoh_flow_python_types::utils::configuration_into_py;
 use zenoh_flow_python_types::Context as PyContext;
 use zenoh_flow_python_types::DataMessage as PyDataMessage;
@@ -69,7 +70,7 @@ impl Sink for PySink {
                     py_data,
                 ),
             )
-            .map_err(|e| ZFError::InvalidData(e.to_string()))?;
+            .map_err(|e| from_pyerr_to_zferr(e, &py))?;
 
         Ok(())
     }
@@ -100,20 +101,20 @@ impl Node for PySink {
                 let py_config = configuration_into_py(py, py_config);
 
                 // Load Python code
-                let code = read_file(script_file_path);
-                let module = PyModule::from_code(py, &code, "sink.py", "sink")
-                    .map_err(|e| ZFError::InvalidData(e.to_string()))?;
-
+                let code = read_file(script_file_path)?;
+                let module =
+                    PyModule::from_code(py, &code, &script_file_path.to_string_lossy(), "sink")
+                        .map_err(|e| from_pyerr_to_zferr(e, &py))?;
                 // Getting the correct python module
                 let sink_class: PyObject = module
                     .call_method0("register")
-                    .map_err(|e| ZFError::InvalidData(e.to_string()))?
+                    .map_err(|e| from_pyerr_to_zferr(e, &py))?
                     .into();
 
                 // Initialize python state
                 let state: PyObject = sink_class
                     .call_method1(py, "initialize", (sink_class.clone(), py_config))
-                    .map_err(|e| ZFError::InvalidData(e.to_string()))?
+                    .map_err(|e| from_pyerr_to_zferr(e, &py))?
                     .into();
 
                 Ok(State::from(PythonState {
@@ -134,7 +135,6 @@ impl Node for PySink {
 zenoh_flow::export_sink!(register);
 
 fn load_self() -> ZFResult<Library> {
-
     log::trace!("Python Sink Wrapper loading Python {}", PY_LIB);
 
     // Very dirty hack!
@@ -155,6 +155,6 @@ fn register() -> ZFResult<Arc<dyn Sink>> {
     Ok(Arc::new(PySink(library)) as Arc<dyn Sink>)
 }
 
-fn read_file(path: &Path) -> String {
-    fs::read_to_string(path).unwrap()
+fn read_file(path: &Path) -> ZFResult<String> {
+    Ok(fs::read_to_string(path)?)
 }

--- a/py-sink/src/lib.rs
+++ b/py-sink/src/lib.rs
@@ -98,7 +98,7 @@ impl Node for PySink {
                 let py_config = config["configuration"].take();
 
                 // Convert configuration to Python
-                let py_config = configuration_into_py(py, py_config);
+                let py_config = configuration_into_py(py, py_config).map_err(|e| from_pyerr_to_zferr(e, &py))?;
 
                 // Load Python code
                 let code = read_file(script_file_path)?;

--- a/py-source/Cargo.toml
+++ b/py-source/Cargo.toml
@@ -10,16 +10,16 @@ edition = "2018"
 zenoh-flow = { git = "https://github.com/eclipse-zenoh/zenoh-flow.git", branch = "master"}
 async-trait = "0.1"
 zenoh-flow-python-types = {path = "../zenoh-flow-python-types/"}
-pyo3 = "0.15"
+pyo3 = "0.16"
 libloading = "0.7"
 log = "0.4"
 
 [build-dependencies]
-pyo3-build-config = {version = "0.15", features = ["resolve-config"]}
+pyo3-build-config = {version = "0.16", features = ["resolve-config"]}
 
 [features]
-abi-py36 = ["pyo3/abi3-py36"]
-default = ["abi-py36"]
+abi-py37 = ["pyo3/abi3-py37"]
+default = ["abi-py37"]
 
 [lib]
 name = "py_source"

--- a/py-source/src/lib.rs
+++ b/py-source/src/lib.rs
@@ -92,7 +92,7 @@ impl Node for PySource {
                 let py_config = config["configuration"].take();
 
                 // Convert configuration to Python
-                let py_config = configuration_into_py(py, py_config);
+                let py_config = configuration_into_py(py, py_config).map_err(|e| from_pyerr_to_zferr(e, &py))?;
 
                 // Load Python code
                 let code = read_file(script_file_path)?;

--- a/py-source/src/lib.rs
+++ b/py-source/src/lib.rs
@@ -6,6 +6,7 @@ use zenoh_flow::async_std::sync::Arc;
 use zenoh_flow::zenoh_flow_derive::ZFState;
 use zenoh_flow::Configuration;
 use zenoh_flow::{Data, Node, Source, State, ZFError, ZFResult};
+use zenoh_flow_python_types::from_pyerr_to_zferr;
 use zenoh_flow_python_types::utils::configuration_into_py;
 use zenoh_flow_python_types::Context as PyContext;
 
@@ -60,9 +61,9 @@ impl Source for PySource {
                     current_state.py_state.as_ref().clone(),
                 ),
             )
-            .map_err(|e| ZFError::InvalidData(e.to_string()))?
+            .map_err(|e| from_pyerr_to_zferr(e, &py))?
             .extract(py)
-            .map_err(|e| ZFError::InvalidData(e.to_string()))?;
+            .map_err(|e| from_pyerr_to_zferr(e, &py))?;
 
         // Converting to rust types
         Ok(Data::from_bytes(value))
@@ -94,20 +95,20 @@ impl Node for PySource {
                 let py_config = configuration_into_py(py, py_config);
 
                 // Load Python code
-                let code = read_file(script_file_path);
-                let module = PyModule::from_code(py, &code, "source.py", "source")
-                    .map_err(|e| ZFError::InvalidData(e.to_string()))?;
-
+                let code = read_file(script_file_path)?;
+                let module =
+                    PyModule::from_code(py, &code, &script_file_path.to_string_lossy(), "source")
+                        .map_err(|e| from_pyerr_to_zferr(e, &py))?;
                 // Getting the correct python module
                 let source_class: PyObject = module
                     .call_method0("register")
-                    .map_err(|e| ZFError::InvalidData(e.to_string()))?
+                    .map_err(|e| from_pyerr_to_zferr(e, &py))?
                     .into();
 
                 // Initialize python state
                 let state: PyObject = source_class
                     .call_method1(py, "initialize", (source_class.clone(), py_config))
-                    .map_err(|e| ZFError::InvalidData(e.to_string()))?
+                    .map_err(|e| from_pyerr_to_zferr(e, &py))?
                     .into();
 
                 Ok(State::from(PythonState {
@@ -148,6 +149,6 @@ fn register() -> ZFResult<Arc<dyn Source>> {
     Ok(Arc::new(PySource(library)) as Arc<dyn Source>)
 }
 
-fn read_file(path: &Path) -> String {
-    fs::read_to_string(path).unwrap()
+fn read_file(path: &Path) -> ZFResult<String> {
+    Ok(fs::read_to_string(path)?)
 }

--- a/zenoh-flow-python-types/Cargo.toml
+++ b/zenoh-flow-python-types/Cargo.toml
@@ -8,12 +8,12 @@ edition = "2018"
 [dependencies]
 zenoh-flow = { git = "https://github.com/eclipse-zenoh/zenoh-flow.git", branch = "master" }
 uhlc = "0.4"
-pyo3 = "0.15"
+pyo3 = "0.16"
 
 
 [features]
-abi-py36 = ["pyo3/abi3-py36"]
-default = ["abi-py36"]
+abi-py37 = ["pyo3/abi3-py37"]
+default = ["abi-py37"]
 
 #[lib]
 #name = "zenoh_flow_python_types"

--- a/zenoh-flow-python-types/src/lib.rs
+++ b/zenoh-flow-python-types/src/lib.rs
@@ -14,7 +14,6 @@
 
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
-use pyo3::PyObjectProtocol;
 use std::collections::HashMap;
 use std::convert::TryInto;
 use std::convert::{From, TryFrom};
@@ -95,10 +94,7 @@ impl DataMessage {
     fn missed_end_to_end_deadlines(&self) -> Vec<E2EDeadlineMiss> {
         self.missed_end_to_end_deadlines.clone()
     }
-}
 
-#[pyproto]
-impl PyObjectProtocol for DataMessage {
     fn __str__(&self) -> PyResult<String> {
         Ok(format!("Timestamp {:?} - Data: {:?}", self.ts, self.data))
     }
@@ -163,10 +159,7 @@ impl Inputs {
             None => None,
         }
     }
-}
 
-#[pyproto]
-impl PyObjectProtocol for Inputs {
     fn __str__(&self) -> PyResult<String> {
         Ok(format!("Total data {}", self.inputs.len()))
     }
@@ -229,10 +222,7 @@ impl Outputs {
             None => None,
         }
     }
-}
 
-#[pyproto]
-impl PyObjectProtocol for Outputs {
     fn __str__(&self) -> PyResult<String> {
         Ok(format!("Total data {}", self.outputs.len()))
     }

--- a/zenoh-flow-python-types/src/lib.rs
+++ b/zenoh-flow-python-types/src/lib.rs
@@ -22,6 +22,14 @@ use zenoh_flow::ZFError;
 
 pub mod utils;
 
+pub fn from_pyerr_to_zferr(py_err: pyo3::PyErr, py: &pyo3::Python<'_>) -> ZFError {
+    let tb = py_err
+        .traceback(*py)
+        .expect("This error should have a traceback");
+    let err_str = format!("{:?}", tb.format());
+    ZFError::InvalidData(err_str)
+}
+
 /// A Zenoh Flow context.
 /// Zenoh Flow context contains a `mode` that represent
 /// the current execution mode for the operator.

--- a/zenoh-flow-python-types/src/utils.rs
+++ b/zenoh-flow-python-types/src/utils.rs
@@ -19,26 +19,27 @@ use std::collections::HashMap;
 use std::convert::TryFrom;
 use zenoh_flow::{ZFError, ZFResult};
 
-pub fn configuration_into_py(py: Python, value: zenoh_flow::Configuration) -> PyObject {
+pub fn configuration_into_py(py: Python, value: zenoh_flow::Configuration) -> PyResult<PyObject> {
     match value {
         zenoh_flow::Configuration::Array(arr) => {
             let py_list = PyList::empty(py);
             for v in arr {
-                py_list.append(configuration_into_py(py, v)).unwrap();
+                py_list.append(configuration_into_py(py, v)?)?;
             }
-            py_list.to_object(py)
+            Ok(py_list.to_object(py))
         }
         zenoh_flow::Configuration::Object(obj) => {
             let py_dict = PyDict::new(py);
             for (k, v) in obj {
-                py_dict.set_item(k, configuration_into_py(py, v)).unwrap();
+                py_dict.set_item(k, configuration_into_py(py, v)?)?;
             }
-            py_dict.to_object(py)
+            Ok(py_dict.to_object(py))
         }
-        zenoh_flow::Configuration::Bool(b) => b.to_object(py),
-        zenoh_flow::Configuration::Number(n) => n.as_u64().unwrap().to_object(py), //TODO convert to the right number
-        zenoh_flow::Configuration::String(s) => s.to_object(py),
-        zenoh_flow::Configuration::Null => py.None(),
+        zenoh_flow::Configuration::Bool(b) => Ok(b.to_object(py)),
+        //FIXME: it should convert to the right type: i64, u64 or f64
+        zenoh_flow::Configuration::Number(n) => Ok(n.as_u64().unwrap().to_object(py)),
+        zenoh_flow::Configuration::String(s) => Ok(s.to_object(py)),
+        zenoh_flow::Configuration::Null => Ok(py.None()),
     }
 }
 

--- a/zenoh-flow-python/Cargo.toml
+++ b/zenoh-flow-python/Cargo.toml
@@ -18,12 +18,12 @@ readme = "../README.md"
 [dependencies]
 zenoh-flow-python-types = { path = "../zenoh-flow-python-types"}
 uhlc = "0.4"
-pyo3 = "0.15"
+pyo3 = "0.16"
 
 [features]
-abi-py36 = ["pyo3/abi3-py36"]
+abi-py37 = ["pyo3/abi3-py37"]
 extension-module = ["pyo3/extension-module"]
-default = ["extension-module", "abi-py36"]
+default = ["extension-module", "abi-py37"]
 
 [lib]
 name = "zenoh_flow"

--- a/zenoh-flow-python/examples/operator.py
+++ b/zenoh-flow-python/examples/operator.py
@@ -29,7 +29,7 @@ class MyState:
 
 class MyOp(Operator):
     def initialize(self, configuration):
-         return MyState()
+        return MyState()
 
     def finalize(self, state):
         return None
@@ -54,7 +54,6 @@ class MyOp(Operator):
     def run(self, _ctx, _state, inputs):
         # Getting the inputs
         data = inputs.get('Data').data
-
         # Computing over the inputs
         int_data = int_from_bytes(data)
         int_data = int_data * 2

--- a/zenoh-flow-python/setup.cfg
+++ b/zenoh-flow-python/setup.cfg
@@ -11,4 +11,4 @@
 
 # As PyO3 is configured with "abi3-py37" feature for stable ABI, we can make the wheel reflect it:
 [bdist_wheel]
-py-limited-api = cp36
+py-limited-api = cp37

--- a/zenoh-flow-python/setup.cfg
+++ b/zenoh-flow-python/setup.cfg
@@ -9,6 +9,6 @@
 #
 # Contributors:
 
-# As PyO3 is configured with "abi3-py36" feature for stable ABI, we can make the wheel reflect it:
+# As PyO3 is configured with "abi3-py37" feature for stable ABI, we can make the wheel reflect it:
 [bdist_wheel]
 py-limited-api = cp36


### PR DESCRIPTION
This PR will move to PyO3 v0.16 and use the `traceback` method to get a proper traceback for Python errors.

- [x] Use traceback
- [x] Remove unwraps
- [x] Fix deprecation warnings 