### PR TITLE
More idiomatic error strings

### DIFF
--- a/zenoh-flow-python-types/src/lib.rs
+++ b/zenoh-flow-python-types/src/lib.rs
@@ -25,7 +25,7 @@ pub fn from_pyerr_to_zferr(py_err: pyo3::PyErr, py: &pyo3::Python<'_>) -> ZFErro
     let tb = py_err
         .traceback(*py)
         .expect("This error should have a traceback");
-    let err_str = format!("{:?}", tb.format());
+    let err_str = format!("Error: {:?}\nTraceback: {:?}", py_err, tb.format());
     ZFError::InvalidData(err_str)
 }
 


### PR DESCRIPTION
Now an error in Python prints the actual error and the backtrace.