### PR TITLE
Fix call to python finalize

### DIFF
--- a/zenoh-flow-python-commons/src/lib.rs
+++ b/zenoh-flow-python-commons/src/lib.rs
@@ -44,12 +44,12 @@ impl Drop for PythonState {
         let py = gil.python();
 
         let py_op = self
-            .module
+            .py_state
             .cast_as::<PyAny>(py)
             .expect("Unable to get Python Node module!");
 
         py_op
-            .call_method1("finalize", (py_op,))
+            .call_method0("finalize")
             .expect("Unable to call Python finalize!");
     }
 }


### PR DESCRIPTION
Changing the way the finalize is called on drop of `PythonState`.
This solves an issue when instance members were not accessible when calling the finalize.