### PR TITLE
Feature: Typed Input and Output

### DIFF
--- a/docs/zenoh-flow-api.rst
+++ b/docs/zenoh-flow-api.rst
@@ -25,9 +25,9 @@ Input
 .. autoclass:: zenoh_flow.Input
     :members:
 
-DataMessage
+Message
 -----------
-.. autoclass:: zenoh_flow.DataMessage
+.. autoclass:: zenoh_flow.Message
     :members:
 
 
@@ -63,7 +63,7 @@ RawInput
     :members:
 
 
-RawDataMessage
+RawMessage
 --------------
-.. autoclass:: zenoh_flow.RawDataMessage
+.. autoclass:: zenoh_flow.RawMessage
     :members:

--- a/docs/zenoh-flow-api.rst
+++ b/docs/zenoh-flow-api.rst
@@ -30,6 +30,17 @@ DataMessage
 .. autoclass:: zenoh_flow.DataMessage
     :members:
 
+
+Outputs
+----------
+.. autoclass:: zenoh_flow.types.Outputs
+    :members:
+
+Inputs
+------------
+.. autoclass:: zenoh_flow.types.Inputs
+    :members:
+
 Context
 -------
 .. autoclass:: zenoh_flow.types.Context
@@ -38,4 +49,21 @@ Context
 Timestamp
 ---------
 .. autoclass:: zenoh_flow.types.Timestamp
+    :members:
+
+
+RawOutput
+----------
+.. autoclass:: zenoh_flow.RawOutput
+    :members:
+
+RawInput
+------------
+.. autoclass:: zenoh_flow.RawInput
+    :members:
+
+
+RawDataMessage
+--------------
+.. autoclass:: zenoh_flow.RawDataMessage
     :members:

--- a/zenoh-flow-python-commons/src/lib.rs
+++ b/zenoh-flow-python-commons/src/lib.rs
@@ -259,7 +259,7 @@ impl RawInput {
                 .recv()
                 .await
                 .map_err(|_| PyValueError::new_err("Unable to receive data"))?;
-            RawDataMessage::try_from(rust_msg)
+            RawMessage::try_from(rust_msg)
         })
     }
 
@@ -304,14 +304,14 @@ impl TryInto<ZInput> for RawInput {
 /// It contains the actual data, the timestamp associated, and
 /// information whether the message is a `Watermark`
 #[pyclass(subclass)]
-pub struct RawDataMessage {
+pub struct RawMessage {
     data: Py<PyBytes>,
     ts: Py<PyLong>,
     is_watermark: bool,
 }
 
 #[pymethods]
-impl RawDataMessage {
+impl RawMessage {
     /// Creates a new [`RawDataMessage`](`RawDataMessage`) with given bytes,
     ///  timestamp and watermark flag.
     #[new]
@@ -342,7 +342,7 @@ impl RawDataMessage {
     }
 }
 
-impl TryFrom<ZFMessage> for RawDataMessage {
+impl TryFrom<ZFMessage> for RawMessage {
     type Error = PyErr;
 
     fn try_from(other: ZFMessage) -> Result<Self, Self::Error> {

--- a/zenoh-flow-python-commons/src/lib.rs
+++ b/zenoh-flow-python-commons/src/lib.rs
@@ -24,10 +24,10 @@ use zenoh_flow::bail;
 
 use zenoh_flow::prelude::{
     zferror, Configuration, Context as ZFContext, Error, ErrorKind, InputRaw as ZInput, Inputs,
-    OutputRaw as ZOutput, Outputs
+    OutputRaw as ZOutput, Outputs,
 };
-use zenoh_flow::types::Payload;
 use zenoh_flow::types::LinkMessage as ZFMessage;
+use zenoh_flow::types::Payload;
 
 use std::sync::Arc;
 

--- a/zenoh-flow-python-commons/src/lib.rs
+++ b/zenoh-flow-python-commons/src/lib.rs
@@ -154,11 +154,12 @@ pub fn inputs_into_py(py: Python, mut inputs: Inputs) -> PyResult<PyObject> {
     let py_receivers = PyDict::new(py);
     let inputs_ids = inputs.keys().cloned().collect::<Vec<_>>();
     for id in &inputs_ids {
-        let input = inputs.take_raw(id).ok_or(PyValueError::new_err(format!("Unable to find input {id}")))?;
+        let input = inputs
+            .take_raw(id)
+            .ok_or_else(|| PyValueError::new_err(format!("Unable to find input {id}")))?;
 
         let pyo3_rx = RawInput::from(input);
         py_receivers.set_item(PyString::new(py, id), &pyo3_rx.into_py(py))?;
-
     }
 
     let py_inputs = py_zenoh_flow.getattr("Inputs")?.call1((py_receivers,))?;
@@ -171,7 +172,9 @@ pub fn outputs_into_py(py: Python, mut outputs: Outputs) -> PyResult<PyObject> {
     let py_senders = PyDict::new(py);
     let outputs_ids = outputs.keys().cloned().collect::<Vec<_>>();
     for id in &outputs_ids {
-        let output = outputs.take_raw(id).ok_or(PyValueError::new_err(format!("Unable to find output {id}")))?;
+        let output = outputs
+            .take_raw(id)
+            .ok_or_else(|| PyValueError::new_err(format!("Unable to find output {id}")))?;
         let pyo3_tx = RawOutput::from(output);
         py_senders.set_item(PyString::new(py, id), &pyo3_tx.into_py(py))?;
     }

--- a/zenoh-flow-python/src/lib.rs
+++ b/zenoh-flow-python/src/lib.rs
@@ -13,12 +13,12 @@
 //
 
 use pyo3::prelude::*;
-use zenoh_flow_python_commons::{InnerDataMessage, InnerInput, InnerOutput};
+use zenoh_flow_python_commons::{RawDataMessage, RawInput, RawOutput};
 
 #[pymodule]
 fn zenoh_flow(_py: Python, m: &PyModule) -> PyResult<()> {
-    m.add_class::<InnerOutput>()?;
-    m.add_class::<InnerInput>()?;
-    m.add_class::<InnerDataMessage>()?;
+    m.add_class::<RawOutput>()?;
+    m.add_class::<RawInput>()?;
+    m.add_class::<RawDataMessage>()?;
     Ok(())
 }

--- a/zenoh-flow-python/src/lib.rs
+++ b/zenoh-flow-python/src/lib.rs
@@ -13,12 +13,12 @@
 //
 
 use pyo3::prelude::*;
-use zenoh_flow_python_commons::{RawDataMessage, RawInput, RawOutput};
+use zenoh_flow_python_commons::{RawInput, RawMessage, RawOutput};
 
 #[pymodule]
 fn zenoh_flow(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<RawOutput>()?;
     m.add_class::<RawInput>()?;
-    m.add_class::<RawDataMessage>()?;
+    m.add_class::<RawMessage>()?;
     Ok(())
 }

--- a/zenoh-flow-python/src/lib.rs
+++ b/zenoh-flow-python/src/lib.rs
@@ -13,12 +13,12 @@
 //
 
 use pyo3::prelude::*;
-use zenoh_flow_python_commons::{DataMessage, Input, Output};
+use zenoh_flow_python_commons::{InnerDataMessage, InnerInput, InnerOutput};
 
 #[pymodule]
 fn zenoh_flow(_py: Python, m: &PyModule) -> PyResult<()> {
-    m.add_class::<Output>()?;
-    m.add_class::<Input>()?;
-    m.add_class::<DataMessage>()?;
+    m.add_class::<InnerOutput>()?;
+    m.add_class::<InnerInput>()?;
+    m.add_class::<InnerDataMessage>()?;
     Ok(())
 }

--- a/zenoh-flow-python/zenoh_flow/__init__.py
+++ b/zenoh-flow-python/zenoh_flow/__init__.py
@@ -182,8 +182,7 @@ Operator:
 '''
 
 
-from .zenoh_flow import InnerInput, InnerOutput, InnerDataMessage
+from .zenoh_flow import RawInput, RawOutput, RawDataMessage
 from zenoh_flow import types
 from .types import Inputs, Outputs, Input, Output, DataMessage
 from zenoh_flow import interfaces
-

--- a/zenoh-flow-python/zenoh_flow/__init__.py
+++ b/zenoh-flow-python/zenoh_flow/__init__.py
@@ -182,7 +182,7 @@ Operator:
 '''
 
 
-from .zenoh_flow import RawInput, RawOutput, RawDataMessage
+from .zenoh_flow import RawInput, RawOutput, RawMessage
 from zenoh_flow import types
-from .types import Inputs, Outputs, Input, Output, DataMessage
+from .types import Inputs, Outputs, Input, Output, Message
 from zenoh_flow import interfaces

--- a/zenoh-flow-python/zenoh_flow/__init__.py
+++ b/zenoh-flow-python/zenoh_flow/__init__.py
@@ -183,7 +183,7 @@ Operator:
 
 
 from .zenoh_flow import InnerInput, InnerOutput, InnerDataMessage
-
-from zenoh_flow import interfaces
 from zenoh_flow import types
-from zenoh_flow.types import Inputs, Outputs, Input, Output, DataMessage
+from .types import Inputs, Outputs, Input, Output, DataMessage
+from zenoh_flow import interfaces
+

--- a/zenoh-flow-python/zenoh_flow/interfaces/operator.py
+++ b/zenoh-flow-python/zenoh_flow/interfaces/operator.py
@@ -12,7 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 
-from zenoh_flow import Input, Output
+from zenoh_flow import Inputs, Outputs
 from zenoh_flow.types import Context
 from typing import Dict, Any
 
@@ -31,9 +31,9 @@ class Operator(object):
     :param configuration: Configuration
     :type configuration: dict
     :param inputs: The input streams
-    :type inputs: :class:`Dict[str, Input]`
+    :type inputs: :class:`Inputs`
     :param outputs: The output streams
-    :type outputs: :class:`Dict[str, Output]`
+    :type outputs: :class:`Outputs`
 
     """
 
@@ -41,8 +41,8 @@ class Operator(object):
         self,
         context: Context,
         configuration: Dict[str, Any],
-        inputs: Dict[str, Input],
-        outputs: Dict[str, Output],
+        inputs: Inputs,
+        outputs: Outputs,
     ):
         """
         The `__init__` method is called by the zenoh flow runtime.
@@ -55,9 +55,9 @@ class Operator(object):
         :param configuration: Configuration
         :type configuration: dict
         :param inputs: The input streams
-        :type inputs: :class:`Dict[str, Input]`
+        :type inputs: :class:`Inputs`
         :param outputs: The output streams
-        :type outputs: :class:`Dict[str, Output]`
+        :type outputs: :class:`Outputs`
 
         :rtype: None
         """

--- a/zenoh-flow-python/zenoh_flow/interfaces/sink.py
+++ b/zenoh-flow-python/zenoh_flow/interfaces/sink.py
@@ -12,7 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 
-from zenoh_flow import Input
+from zenoh_flow import Inputs
 from zenoh_flow.types import Context
 from typing import Dict, Any
 
@@ -31,14 +31,14 @@ class Sink(object):
     :param configuration: Configuration
     :type configuration: dict
     :param inputs: The input streams
-    :type inputs: :class:`Dict[str, Input]`
+    :type inputs: :class:`Inputs`
     """
 
     def __init__(
         self,
         context: Context,
         configuration: Dict[str, Any],
-        inputs: Dict[str, Input],
+        inputs: Inputs,
     ):
         """
         The `__init__` method is called by the Zenoh Flow runtime.
@@ -51,7 +51,7 @@ class Sink(object):
         :param configuration: Configuration
         :type configuration: dict
         :param inputs: The input streams
-        :type inputs: :class:`Dict[str, Input]`
+        :type inputs: :class:`Inputs`
 
         :rtype: None
         """

--- a/zenoh-flow-python/zenoh_flow/interfaces/source.py
+++ b/zenoh-flow-python/zenoh_flow/interfaces/source.py
@@ -13,7 +13,7 @@
 #
 
 
-from zenoh_flow import Output
+from zenoh_flow import Outputs
 from zenoh_flow.types import Context
 from typing import Any, Dict
 
@@ -32,7 +32,7 @@ class Source(object):
     :param configuration: Configuration
     :type configuration: dict
     :param outputs: The output streams
-    :type outputs: :class:`Dict[str, Output]`
+    :type outputs: :class:`Outputs`
 
     """
 
@@ -40,7 +40,7 @@ class Source(object):
         self,
         context: Context,
         configuration: Dict[str, Any],
-        outputs: Dict[str, Output],
+        outputs: Outputs,
     ):
         """
         The `__init__` method is called by the zenoh flow runtime.
@@ -53,7 +53,7 @@ class Source(object):
         :param configuration: Configuration
         :type configuration: dict`
         :param outputs: The output streams
-        :type outputs: :class:`Dict[str, Output]`
+        :type outputs: :class:`Outputs`
 
         :rtype: None
         """

--- a/zenoh-flow-python/zenoh_flow/types/__init__.py
+++ b/zenoh-flow-python/zenoh_flow/types/__init__.py
@@ -196,6 +196,21 @@ class Inputs:
             return None
         in_stream = Input(in_stream, input_type, deserializer)
 
+    def take_raw(self,  port_id: str) -> InnerInput:
+        """
+        Returns the InnerInput associated to the provided `port_id`,
+        if one is associated, otherwise `None` is returned.
+
+        A InnerInput receives bytes not typed data
+
+        Args:
+            port_id (str): Id associated with the input
+
+        Returns:
+            InnerInput: The raw associated input
+        """
+        return self.__inputs.get(port_id, None)
+
 
 class Outputs:
     """
@@ -224,4 +239,19 @@ class Outputs:
         if out_stream is None:
             return None
         out_stream = Output(out_stream, output_type, serializer)
+
+    def take_raw(self,  port_id: str) -> InnerOutput:
+        """
+        Returns the InnerOutput associated to the provided `port_id`,
+        if one is associated, otherwise `None` is returned.
+
+        A InnerOutput receives bytes not typed data
+
+        Args:
+            port_id (str): Id associated with the output
+
+        Returns:
+            InnerOutput: The raw associated output
+        """
+        return self.__outputs.get(port_id, None)
 

--- a/zenoh-flow-python/zenoh_flow/types/__init__.py
+++ b/zenoh-flow-python/zenoh_flow/types/__init__.py
@@ -191,7 +191,7 @@ class Inputs:
             Input: The typed associated input
 
         """
-        in_stream = self.__input.get(port_id, None)
+        in_stream = self.__inputs.get(port_id, None)
         if in_stream is None:
             return None
         in_stream = Input(in_stream, input_type, deserializer)

--- a/zenoh-flow-python/zenoh_flow/types/__init__.py
+++ b/zenoh-flow-python/zenoh_flow/types/__init__.py
@@ -195,6 +195,7 @@ class Inputs:
         if in_stream is None:
             return None
         in_stream = Input(in_stream, input_type, deserializer)
+        return in_stream
 
     def take_raw(self,  port_id: str) -> InnerInput:
         """
@@ -210,6 +211,12 @@ class Inputs:
             InnerInput: The raw associated input
         """
         return self.__inputs.get(port_id, None)
+
+    def __repr__(self):
+        return self.__str__()
+
+    def __str__(self):
+        return f"Inputs(__inputs={self.__inputs})"
 
 
 class Outputs:
@@ -239,6 +246,7 @@ class Outputs:
         if out_stream is None:
             return None
         out_stream = Output(out_stream, output_type, serializer)
+        return out_stream
 
     def take_raw(self,  port_id: str) -> InnerOutput:
         """
@@ -255,3 +263,8 @@ class Outputs:
         """
         return self.__outputs.get(port_id, None)
 
+    def __repr__(self):
+        return self.__str__()
+
+    def __str__(self):
+        return f"Outputs(__outputs={self.__outputs})"

--- a/zenoh-flow-python/zenoh_flow/types/__init__.py
+++ b/zenoh-flow-python/zenoh_flow/types/__init__.py
@@ -13,8 +13,11 @@
 #
 
 
-from zenoh_flow import Input, Output, DataMessage
-from typing import Callable
+from zenoh_flow import InnerInput, InnerOutput
+from typing import Callable, Any, TypeVar, Optional, Dict
+
+
+T = TypeVar("T")
 
 
 class Context(object):
@@ -72,3 +75,153 @@ class Timestamp(object):
 
     def __str__(self):
         return f"Timestamp(ntp={self.ntp}, id={self.id})"
+
+
+class DataMessage:
+    """
+    Zenoh Flow data messages
+    It contains the actual data, the timestamp associated, and
+    information whether the message is a `Watermark`
+    """
+    def __init__(self, data: Any, ts: int,  watermark: bool):
+        self.__data = data
+        self.__ts = ts
+        self.__watermark = watermark
+
+    def get_data(self) -> Any:
+        """
+        Returns a reference over bytes representing the data.
+        """
+        return self.__data
+
+    def get_ts(self) -> int:
+        """
+        Returns the data timestamp.
+        """
+        return self.__ts
+
+    def is_watermark(self) -> bool:
+        """
+        Returns whether the `DataMessage` is a watermark or not.
+        """
+        return self.__watermark
+
+
+class Input:
+    """
+    Channel that receives data from upstream nodes.
+    """
+    def __init__(self, inner: InnerInput, input_type: T, deserializer: Callable[[bytes], T]):
+        self.__deserializer = deserializer
+        self.__inner = inner
+        self.__type = input_type
+
+    async def recv(self) -> DataMessage:
+        """
+        Returns the first `DataMessage` that was received, *asynchronously*,
+        on any of the channels associated with this Input.
+
+        If several `DataMessage` are received at the same time,
+        one is randomly selected.
+        """
+        data_msg = await self.__inner.recv()
+        data = None
+        if len(data_msg.data) > 0:
+            data = self.__deserializer(data_msg.data)
+        msg = DataMessage(data, data_msg.ts, data_msg.is_watermark)
+        return msg
+
+    def port_id(self) -> str:
+        """
+        Returns the ID associated with this `Input`.
+        """
+        return self.__inner.port_id()
+
+
+class Output:
+    """
+    Channels that sends data to downstream nodes.
+    """
+    def __init__(self, inner: InnerOutput, output_type: T, serializer: Callable[[T], bytes]):
+        self.__serializer = serializer
+        self.__inner = inner
+        self.__type = output_type
+
+    async def send(self, data: T, ts: Optional[int] = None):
+        """_summary_
+        Send, *asynchronously*, the data on all channels.
+
+        If no timestamp is provided, the current timestamp
+        — as per the HLC — is taken.
+
+        If an error occurs while sending the message on a channel,
+        we still try to send it on the remaining channels.
+        For each failing channel, an error is logged and counted for.
+        """
+        ser_data = self.__serializer(data)
+        return await self.__inner.send(ser_data, ts)
+
+    def port_id(self) -> str:
+        """
+        Returns the ID associated with this `Output`.
+        """
+        return self.__inner.port_id()
+
+
+class Inputs:
+    """
+     The `Inputs` structure contains all the receiving channels
+     we created for a `Sink` or an `Operator`.
+    """
+    def __init__(self, inputs: Dict[str, InnerInput]):
+        self.__inputs = inputs
+
+    def take(self, port_id: str, input_type: T,  deserializer: Callable[[bytes], T]) -> Input:
+        """
+        Returns the typed `Input` associated to the provided `port_id`,
+        if one is associated, otherwise `None` is returned.
+
+        Args:
+            port_id (str): Id associated with the input
+            input_type (T): Type of data being received into this input
+            deserializer (Callable[[bytes], T]): Deserialization function
+                for the given type.
+
+        Returns:
+            Input: The typed associated input
+
+        """
+        in_stream = self.__input.get(port_id, None)
+        if in_stream is None:
+            return None
+        in_stream = Input(in_stream, input_type, deserializer)
+
+
+class Outputs:
+    """
+    The `Outputs` structure contains all the sender channels
+    we created for a `Source` or an `Operator`.
+    """
+    def __init__(self, outputs: Dict[str, InnerOutput]):
+        self.__outputs = outputs
+
+    def take(self, port_id: str, output_type: T,  serializer: Callable[[T], bytes]) -> Output:
+        """
+
+        Returns the typed `Output` associated to the provided `port_id`,
+        if one is associated, otherwise `None` is returned.
+
+        Args:
+            port_id (str): Id associated with the output
+            output_type (T): Type of data being sent to this output
+            serializer (Callable[[T], bytes]): Serialization function
+                for the given type.
+
+        Returns:
+            Output: The typed associated output
+        """
+        out_stream = self.__outputs.get(port_id, None)
+        if out_stream is None:
+            return None
+        out_stream = Output(out_stream, output_type, serializer)
+

--- a/zenoh-flow-python/zenoh_flow/types/__init__.py
+++ b/zenoh-flow-python/zenoh_flow/types/__init__.py
@@ -75,10 +75,10 @@ class Timestamp(object):
 
 class Message:
     """
-    Zenoh Flow data messages
-    It contains the actual data, the timestamp associated, and
-    information whether the message is a `Watermark`
-    If the message is a `Watermark` the data is an empty list.
+    A Zenoh-Flow message: a timestamp and optional data.
+
+    If the message is a `Watermark` then no data is associated and
+    `get_data` will return an empty list.
     """
 
     def __init__(self, data: Any, ts: int, watermark: bool):

--- a/zenoh-flow-python/zenoh_flow/types/__init__.py
+++ b/zenoh-flow-python/zenoh_flow/types/__init__.py
@@ -13,7 +13,7 @@
 #
 
 
-from zenoh_flow import InnerInput, InnerOutput
+from zenoh_flow import RawInput, RawOutput
 from typing import Callable, Any, TypeVar, Optional, Dict
 
 
@@ -90,7 +90,7 @@ class DataMessage:
 
     def get_data(self) -> Any:
         """
-        Returns a reference over bytes representing the data.
+        Returns the typed data.
         """
         return self.__data
 
@@ -111,7 +111,7 @@ class Input:
     """
     Channel that receives data from upstream nodes.
     """
-    def __init__(self, inner: InnerInput, input_type: T, deserializer: Callable[[bytes], T]):
+    def __init__(self, inner: RawInput, input_type: T, deserializer: Callable[[bytes], T]):
         self.__deserializer = deserializer
         self.__inner = inner
         self.__type = input_type
@@ -142,13 +142,13 @@ class Output:
     """
     Channels that sends data to downstream nodes.
     """
-    def __init__(self, inner: InnerOutput, output_type: T, serializer: Callable[[T], bytes]):
+    def __init__(self, inner: RawOutput, output_type: T, serializer: Callable[[T], bytes]):
         self.__serializer = serializer
         self.__inner = inner
         self.__type = output_type
 
     async def send(self, data: T, ts: Optional[int] = None):
-        """_summary_
+        """
         Send, *asynchronously*, the data on all channels.
 
         If no timestamp is provided, the current timestamp
@@ -173,7 +173,7 @@ class Inputs:
      The `Inputs` structure contains all the receiving channels
      we created for a `Sink` or an `Operator`.
     """
-    def __init__(self, inputs: Dict[str, InnerInput]):
+    def __init__(self, inputs: Dict[str, RawInput]):
         self.__inputs = inputs
 
     def take(self, port_id: str, input_type: T,  deserializer: Callable[[bytes], T]) -> Input:
@@ -197,18 +197,18 @@ class Inputs:
         in_stream = Input(in_stream, input_type, deserializer)
         return in_stream
 
-    def take_raw(self,  port_id: str) -> InnerInput:
+    def take_raw(self,  port_id: str) -> RawInput:
         """
-        Returns the InnerInput associated to the provided `port_id`,
+        Returns the RawInput associated to the provided `port_id`,
         if one is associated, otherwise `None` is returned.
 
-        A InnerInput receives bytes not typed data
+        A RawInput receives bytes not typed data
 
         Args:
             port_id (str): Id associated with the input
 
         Returns:
-            InnerInput: The raw associated input
+            RawInput: The raw associated input
         """
         return self.__inputs.get(port_id, None)
 
@@ -224,7 +224,7 @@ class Outputs:
     The `Outputs` structure contains all the sender channels
     we created for a `Source` or an `Operator`.
     """
-    def __init__(self, outputs: Dict[str, InnerOutput]):
+    def __init__(self, outputs: Dict[str, RawOutput]):
         self.__outputs = outputs
 
     def take(self, port_id: str, output_type: T,  serializer: Callable[[T], bytes]) -> Output:
@@ -248,18 +248,18 @@ class Outputs:
         out_stream = Output(out_stream, output_type, serializer)
         return out_stream
 
-    def take_raw(self,  port_id: str) -> InnerOutput:
+    def take_raw(self,  port_id: str) -> RawOutput:
         """
-        Returns the InnerOutput associated to the provided `port_id`,
+        Returns the RawOutput associated to the provided `port_id`,
         if one is associated, otherwise `None` is returned.
 
-        A InnerOutput receives bytes not typed data
+        A RawOutput receives bytes not typed data
 
         Args:
             port_id (str): Id associated with the output
 
         Returns:
-            InnerOutput: The raw associated output
+            RawOutput: The raw associated output
         """
         return self.__outputs.get(port_id, None)
 


### PR DESCRIPTION
This feature provides typed inputs and outputs for the Python API.

It is not possible to have typed inputs and outputs in Python similar to what can be done in rust.

Users must pass a serialization (output) or a deserialization (input) function when getting the Input/Output.


Here is an example:
```python
    class MyOp(Operator):
        def __init__(
            self,
            context: Context,
            configuration: Dict[str, Any],
            inputs: Inputs,
            outputs: Outputs,
        ):
            self.output = outputs.take("Data", int, int_to_bytes)
            self.in_stream = inputs.take("Data", int, bytes_to_int)
       ...
```

~Still to be discussed if we keep the possibility to get `raw` Inputs/outputs where the user can send/receive bytes.~


Users can still get access to the `raw` inputs and outputs by calling `take_raw`. 