### PR TITLE
docs: fix extensions file content

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,24 +64,21 @@ You need to change the configuration of Zenoh-Flow to let it know how to load Py
 *If* you launched the Zenoh-Flow runtime in a **standalone** fashion, you need to provide a configuration that contains the following:
 
 ```yaml
-name: my-zenoh-flow
-
-extensions:
-  - file_extension: py
-    libraries:
-      # Linux
-      sink: /path/to/zenoh-flow-python/target/release/libzenoh_flow_python_sink_wrapper.so
-      operator: /path/to/zenoh-flow-python/target/release/libzenoh_flow_python_operator_wrapper.so
-      source: /path/to/zenoh-flow-python/target/release/libzenoh_flow_python_source_wrapper.so
-      # macOS
-      # sink: /path/to/zenoh-flow-python/target/release/libzenoh_flow_python_sink_wrapper.dylib
-      # operator: /path/to/zenoh-flow-python/target/release/libzenoh_flow_python_operator_wrapper.dylib
-      # source: /path/to/zenoh-flow-python/target/release/libzenoh_flow_python_source_wrapper.dylib
+- file_extension: py
+  libraries:
+    # Linux
+    sink: /path/to/zenoh-flow-python/target/release/libzenoh_flow_python_sink_wrapper.so
+    operator: /path/to/zenoh-flow-python/target/release/libzenoh_flow_python_operator_wrapper.so
+    source: /path/to/zenoh-flow-python/target/release/libzenoh_flow_python_source_wrapper.so
+    # macOS
+    # sink: /path/to/zenoh-flow-python/target/release/libzenoh_flow_python_sink_wrapper.dylib
+    # operator: /path/to/zenoh-flow-python/target/release/libzenoh_flow_python_operator_wrapper.dylib
+    # source: /path/to/zenoh-flow-python/target/release/libzenoh_flow_python_source_wrapper.dylib
 ```
 
 *If* you launched Zenoh-Flow as a **Zenoh plugin**, you need to update the Zenoh configuration with the following:
 
-```json
+```json5
 {
     "plugins": {
         "zenoh_flow": {

--- a/examples/zenoh-flow-configuration.yaml
+++ b/examples/zenoh-flow-configuration.yaml
@@ -1,8 +1,5 @@
-name: zf-python
-
-extensions:
-  - file_extension: py
-    libraries:
-      sink: /Users/julien/dev/zenoh-flow-python-2/target/debug/libzenoh_flow_python_sink_wrapper_2.dylib
-      source: /Users/julien/dev/zenoh-flow-python-2/target/debug/libzenoh_flow_python_sink_wrapper_2.dylib
-      operator: /Users/julien/dev/zenoh-flow-python-2/target/debug/libzenoh_flow_python_sink_wrapper_2.dylib
+- file_extension: py
+  libraries:
+    sink: /Users/julien/dev/zenoh-flow-python/target/debug/libzenoh_flow_python_sink_wrapper.dylib
+    source: /Users/julien/dev/zenoh-flow-python/target/debug/libzenoh_flow_python_source_wrapper.dylib
+    operator: /Users/julien/dev/zenoh-flow-python/target/debug/libzenoh_flow_python_operator_wrapper.dylib


### PR DESCRIPTION
The extensions file should only consists of a sequence of `extensions` structures. In particular, it should not have a `name` section.

Both the README and the example were fixed.

* README.md: fix content of extensions file.
* examples/zenoh-flow-configuration.yaml: fix content.